### PR TITLE
Fix: 배포 페이지 이동 오휴 해결

### DIFF
--- a/src/vercel.json
+++ b/src/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #8 

## 📝 작업 내용
> vercel 배포시 라우팅 404 에러 해결

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/3d555534-fca9-40d7-b455-a70690ecd778)

